### PR TITLE
[Update] - Update SnarkVM to post mainnet rev `3d42aa0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "lib.rs"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkvm.git"
-rev = "02994a1"
+rev = "3d42aa0"
 
 [dependencies.anyhow]
 version = "1.0"


### PR DESCRIPTION
## Motivation

This PR updates the HTTP Client to the post mainnet rev `3d42aa0`