### PR TITLE
[Feature] Add u128 support to Serde deserializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rusty-hook",
+ "serde_json",
  "snarkvm",
  "tokio",
  "tokio-test",
@@ -1805,12 +1806,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ version = "1.7.0"
 [dependencies.reqwest]
 version = "0.11"
 
+[dependencies.serde_json]
+version = "1.0.128"
+features = ["arbitrary_precision"]
+
 [dependencies.tokio]
 version = "1.0"
 features = [ "macros", "rt-multi-thread"]

--- a/client/asynchronous.rs
+++ b/client/asynchronous.rs
@@ -584,5 +584,9 @@ mod tests {
             assert_eq!(block.height(), start_height);
             start_height += 1;
         });
+
+        // Get the latest block and check the height is greater than 1,000,000.
+        let block = client.latest_block().await.unwrap();
+        assert!(block.height() > 1_000_000);
     }
 }


### PR DESCRIPTION
## Motivation

Structs with u128 members relating to proof data (such as the `cumulative_weight` member of the `Header` object) by default deserialize as `f64` types instead of `u128` causing block deserialization to fail within Rust code using libraries employing Serde deserialization deserializing blocks from JSON. 

As a workaround the `arbitrary_precision` flag is turned on for the `serde_json` library.